### PR TITLE
Fix architecture

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,13 +12,12 @@ rec {
   inherit (pkgs) lib;
 
   ledgerPkgs = pkgsFunc {
+    config.allowUnsupportedSystem = true;
     crossSystem = {
       isStatic = true;
-      config = "armv6l-unknown-none-eabi";
-      #useLLVM = true;
+      config = "armv6m-unknown-none-eabi";
       gcc = {
-        arch = "armv6t2";
-        fpu = "vfpv2";
+        arch = "armv6s-m";
       };
       rustc = {
         arch = "thumbv6m";

--- a/dep/speculos/github.json
+++ b/dep/speculos/github.json
@@ -3,6 +3,6 @@
   "repo": "speculos",
   "branch": "with-nix-build",
   "private": false,
-  "rev": "cf1ef6347ba0bf1d5444bd008c669813f9b42c85",
-  "sha256": "0w6kiiwvq1b5mywxa30zck8ap4gd7a7f0g1nmh3qawyjv6akf7m5"
+  "rev": "d62633395af394534ebb69db7ea9dc3f3da19647",
+  "sha256": "0165mnwb57vp2gahgagq86m7avd26hclm8wlwzrwl1pbxd931d70"
 }


### PR DESCRIPTION
The armv6s-m arch (Cortex-M0 + OS extension) appears to be the correct architecture for the sc000 core on the ledger; nixpkgs doesn't explicitly provide support but setting the arch in gcc produces assembly that appears correct and not to include any instructions not present on the sc000.