### PR TITLE
Always allow unstable features with crate2nix builds

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -9,8 +9,9 @@ rec {
 
   extraArgsForAllCrates = pkgs: let
     isBolos = platformIsBolos pkgs.stdenv.hostPlatform;
-  in args: args // lib.optionalAttrs isBolos {
+  in args: args // {
       RUSTC_BOOTSTRAP = true;
+    } // lib.optionalAttrs isBolos {
       extraRustcOpts = [
         "-C" "opt-level=3"
         "-C" "codegen-units=1"


### PR DESCRIPTION
Before we were just allowing them for cross-compiled crates, which doesn't make much sense.